### PR TITLE
Don't crash the server when clients send empty string

### DIFF
--- a/connectionHandler.go
+++ b/connectionHandler.go
@@ -110,6 +110,9 @@ func handleConnection(conn net.Conn) {
 		log.Print("Received from client: ", data)
 
 		stringData := strings.Fields(data)
+		if len(stringData) == 0 {
+			continue
+		}
 
 		/*
 			SET key value EX time_in_seconds


### PR DESCRIPTION
Right now sending an empty string as a command (just pressing "enter" using `nc` or the client, even by mistake) crashes the server.

BTW really neat little thing you wrote, I had a lot of fun reading the code and learned a few things. GG! 🚀 